### PR TITLE
Fix Routing Returning Callback

### DIFF
--- a/lib/modules/modules/i_module_routes.dart
+++ b/lib/modules/modules/i_module_routes.dart
@@ -16,7 +16,7 @@ abstract class IOrchModuleRoutes {
               'A route was attempted to be navigated to withtout the context of [CoreNavigator] being available, this is likely due to the [CoreNavigator] not being attached to the root [MaterialApp] at such point. \n');
       return null;
     }
-    callback();
+    return callback();
   }
 
   @mustCallSuper


### PR DESCRIPTION
It is important to return the callback so we can use async statements whe routing, as waiting for route response